### PR TITLE
Added Django 2.0 compatibility

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,6 +12,8 @@ from translation_manager.settings import get_settings
 if get_settings('TRANSLATIONS_PROCESSING_METHOD') == 'async_django_rq':
     from django_rq import get_queue, get_worker
 
+import django
+
 class TranslationCase(TestCase):
     def setUp(self):
         self.username = 'test_user'
@@ -39,7 +41,10 @@ class TranslationCase(TestCase):
         self.assertEqual(entry.locale_parent_dir, 'tests')
 
     def test_makemessages_django_1_4_19(self):
-        call_command('makemessages')
+        if django.get_version() >= "2":
+            call_command('makemessages', add_location='full')
+        else:
+            call_command('makemessages')
 
     if get_settings('TRANSLATIONS_PROCESSING_METHOD') == 'async_django_rq':
         def test_makemessages_django_rq_single_run(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = {py27,py34,py35}-django110,
+envlist = {py34,py35}-django202,
+          {py27,py34,py35}-django110,
           {py27,py34,py35}-django19,
           {py27,py34,py35}-django18,
 
@@ -21,3 +22,7 @@ deps =
     django110: django-rq==0.9.1
     django110: django-redis-cache==1.6.5
     django110: djangorestframework==3.4.6
+    django202: django==2.0.2
+    django202: django-rq==1.0.1
+    django202: django-redis-cache==1.7.1
+    django202: djangorestframework==3.7.7

--- a/translation_manager/admin.py
+++ b/translation_manager/admin.py
@@ -1,7 +1,12 @@
 from functools import update_wrapper
 
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
+
 from django.http import HttpResponseRedirect, JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings

--- a/translation_manager/management/commands/makemessages.py
+++ b/translation_manager/management/commands/makemessages.py
@@ -13,37 +13,14 @@ from translation_manager.settings import get_settings
 
 
 class Command(OriginCommand):
+
     def add_arguments(self, parser):
-        parser.add_argument('--locale', '-l', default=[], dest='locale', action='append',
-                            help='Creates or updates the message files for the given locale(s) (e.g. pt_BR). '
-                                 'Can be used multiple times.'),
-        parser.add_argument('--exclude', '-x', default=[], dest='exclude', action='append',
-                            help='Locales to exclude. Default is none. Can be used multiple times.'),
-        parser.add_argument('--domain', '-d', default=get_settings('TRANSLATIONS_DOMAINS') or ['django', 'djangojs'],
-                            dest='domain',
-                            help='The domain of the message files (default: "django").'),
-        parser.add_argument('--all', '-a', action='store_true', dest='all',
-                            default=True, help='Updates the message files for all existing locales.'),
-        parser.add_argument('--extension', '-e', dest='extensions',
-                            help='The file extension(s) to examine (default: "html,txt", or "js" if the domain is "djangojs"). Separate multiple extensions with commas, or use -e multiple times.',
-                            action='append'),
-        parser.add_argument('--symlinks', '-s', action='store_true', dest='symlinks',
-                            default=False,
-                            help='Follows symlinks to directories when examining source code and templates for translation strings.'),
-        parser.add_argument('--ignore', '-i', action='append', dest='ignore_patterns',
-                            default=get_settings('TRANSLATIONS_IGNORED_PATHS') or [], metavar='PATTERN',
-                            help='Ignore files or directories matching this glob-style pattern. Use multiple times to ignore more.'),
-        parser.add_argument('--no-default-ignore', action='store_false', dest='use_default_ignore_patterns',
-                            default=True,
-                            help="Don't ignore the common glob-style patterns 'CVS', '.*', '*~' and '*.pyc'."),
-        parser.add_argument('--no-wrap', action='store_true', dest='no_wrap',
-                            default=False, help="Don't break long message lines into several lines."),
-        parser.add_argument('--no-location', action='store_true', dest='no_location',
-                            default=False, help="Don't write '#: filename:line' lines."),
-        parser.add_argument('--no-obsolete', action='store_true', dest='no_obsolete',
-                            default=False, help="Remove obsolete message strings."),
-        parser.add_argument('--keep-pot', action='store_true', dest='keep_pot',
-                            default=False, help="Keep .pot file after making messages. Useful when debugging."),
+
+        # Call method of supperclass to give all parser arguments
+        parser = super(Command, self).add_arguments(parser)
+        # here is place to add new arguments.
+
+        return parser
 
     def gettext_angular_js(self):
         all_files = self.find_files(get_settings('TRANSLATIONS_API_CLIENT_APP_SRC_PATH'))

--- a/urls.py
+++ b/urls.py
@@ -5,7 +5,7 @@ from translation_manager import urls as translation_urls
 from translation_manager.settings import get_settings
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^django-rq/', include('django_rq.urls')),
     url(r'^translations/', include(translation_urls))
 ]


### PR DESCRIPTION
Changes: 

1. makemessages command reqires add_location in django 2.0 (tests/tests.py)
2. Updated environment list (only python 3.4 and 3.5 is supported by django 2.0)
3. In django 2.0 environment added latest versions of django, django rest framework and other libraries.
4. Handled import error for reverse method in django which have different paths for 1.x and 2.0 versions.
5. Added super call to makemessages command (i think that this method was copied from django for some reason, but django 2.0 have new parameters, much better is to call super and reuse django code, also i double checked all options are allready there in original django command).
6. New way to include admin.site.urls, old way is removed from django 2.0