### PR TITLE
Write binary to the po file

### DIFF
--- a/translation_manager/models.py
+++ b/translation_manager/models.py
@@ -92,7 +92,7 @@ class TranslationBackup(models.Model):
         mo_filename = os.path.join(self.locale_path, self.language, 'LC_MESSAGES',
                                    self.domain + '.mo')
 
-        with open(po_filename, 'w') as output:
+        with open(po_filename, 'wb') as output:
             output.write(self.content.encode('utf-8'))
 
         po = polib.pofile(po_filename)


### PR DESCRIPTION
This PR fixes the restore ability by making sure that the po file is opened for writing binary. This resolves #38. 